### PR TITLE
testtotalkcal fiks

### DIFF
--- a/src/no/hvl/dat100ptc/test/GPSComputerTester.java
+++ b/src/no/hvl/dat100ptc/test/GPSComputerTester.java
@@ -82,7 +82,7 @@ public class GPSComputerTester {
 	
 	@Test
 	public void testtotalkcal () {
-		assertEquals(24.89,gpscomp.totalKcal(80.0),0.01);
+		assertEquals(28.44,gpscomp.totalKcal(80.0),0.01);
 		
 	}
 	


### PR DESCRIPTION
Har en mistanke om at en beregning ikke er med i summen. Nest siste utregning gir totalt 24.888... ~ 24.89 som det står i testen. Siste gir 28.444... ~ 28.44.

debug:
```
0: 3.5555555555555554 kcal - sum: 3.5555555555555554
1: 10.666666666666666 kcal - sum: 14.222222222222221
2: 10.666666666666666 kcal - sum: 24.888888888888886
3: 3.5555555555555554 kcal - sum: 28.444444444444443
totalt: 28.444444444444443 kcal
```